### PR TITLE
Enable 'Build library for distribution' for Swift stability

### DIFF
--- a/SVGPath.xcodeproj/project.pbxproj
+++ b/SVGPath.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 		158403751A70B5E2002EE42F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -406,6 +407,7 @@
 		158403761A70B5E2002EE42F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";


### PR DESCRIPTION
Added this because of recent Jenkins troubles. According to this WWDC video https://developer.apple.com/videos/play/wwdc2019/416/ this setting should allow an older compiled version of this dependency to be compatible with future releases of Swift. Since we are using Rome to cache the compiled version instead of compiling this often, I see the need to have this build setting.